### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "python TomeRater.py"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # TomeRater
 Code_Academy Capstone Project
+Language: Python3
+
+Command-line program to simulate a book review application. This project was my first python project that consolidated the skills learnt over the 12week intensive python course. The project required skills including utilising and understanding:
+- Python programming fundementals & advanced structures
+- OOP
+- Inheritance
+- regex(for email verification)
+[![Run on Repl.it](https://repl.it/badge/github/jleg13/TomeRater)](https://repl.it/github/jleg13/TomeRater)
+


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@jleg13/TomeRater).